### PR TITLE
Support camera passthrough on WebARonARKit

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you run these apps on a device with no VR or AR tracking, the apps will use t
 
 ## Supported Realities
 
-- Camera Reality (ARKit on Mozilla iOS Test App, WebARonARCore on Android, WebARonARKit on iOS (NOT YET), WebRTC video stream (PARTIAL))
+- Camera Reality (ARKit on Mozilla iOS Test App, WebARonARCore on Android, WebARonARKit on iOS, WebRTC video stream (PARTIAL))
 - Virtual Reality (Desktop Firefox with Vive and Rift, Daydream (NOT TESTED), GearVR (Not Tested), Edge with MS MR headsets (NOT TESTED))
 - Passthrough Reality (NOT YET)
 
@@ -72,7 +72,7 @@ If you run these apps on a device with no VR or AR tracking, the apps will use t
 
 - Mozilla [WebXR Playground](https://github.com/mozilla/webxr-ios) iOS App using ARKit
 - Google [ARCore Test Chrome on Android](https://github.com/google-ar/WebARonARCore)
-- Google [ARCore Test Chrome on iOS](https://github.com/google-ar/WebARonARKit) (NOT YET)
+- Google [ARKit Test Chrome on iOS](https://github.com/google-ar/WebARonARKit)
 - Desktop Firefox with WebVR 1.1 HMDs
 - Mobile Safari, Chrome, and Firefox (PARTIAL, Daydream NOT TESTED)
 - GearVR Internet (NOT TESTED)

--- a/polyfill/reality/CameraReality.js
+++ b/polyfill/reality/CameraReality.js
@@ -72,8 +72,10 @@ export default class CameraReality extends Reality {
 	Called by a session before it hands a new XRPresentationFrame to the app
 	*/
 	_handleNewFrame(frame){
-		if(this._arCoreCameraRenderer){
-			this._arCoreCameraRenderer.render()
+		if(this._vrDisplay){
+			if (this._arCoreCameraRenderer) {
+				this._arCoreCameraRenderer.render()
+			}
 			this._vrDisplay.getFrameData(this._vrFrameData)
 		}
 
@@ -84,8 +86,12 @@ export default class CameraReality extends Reality {
 		if(this._running) return
 		this._running = true
 
-		if(this._vrDisplay !== null){ // Using ARCore
-			this._arCoreCameraRenderer = new ARCoreCameraRenderer(this._vrDisplay, this._elContext)
+		if(this._vrDisplay !== null){ // Using WebAR
+			if (window.WebARonARKitSetData) {
+				// WebARonARKit renders camera separately
+			} else {
+				this._arCoreCameraRenderer = new ARCoreCameraRenderer(this._vrDisplay, this._elContext)
+			}
 			this._initialized = true
 		} else if(ARKitWrapper.HasARKit()){ // Using ARKit
 			if(this._initialized === false){


### PR DESCRIPTION
WebARonARKit exposes the same WebAR API as WebARonARCore, but implements camera rendering separately. So, when we detect WebARonARKit (by checking for the main window method it uses), we don't do the ARCore camera rendering, but still do the WebAR updating.